### PR TITLE
Adding unmanaged lifetime scoping

### DIFF
--- a/lib/lifecycle.ts
+++ b/lib/lifecycle.ts
@@ -14,6 +14,11 @@ import { IDisposable } from "./interfaces";
 export enum Lifetime
 {
     /**
+     * Object is not managed by the framework's lifetime.
+     */
+    Unmanaged,
+
+    /**
      * A new object is created on each request to resolve().
      */
     Transient,
@@ -57,6 +62,21 @@ export function using<T extends IDisposable>(item: T, fn: (item: T) => void): vo
         if (item != null)
             item.dispose();
     }
+}
+
+/* ================================================================================================================= */
+/**
+ * Calls an object's dispose() method if found.
+ *
+ * @param item The item to call dispose on if available.
+ */
+export function maybeDispose(item: any): void
+{
+    if (item == null)
+        return;
+
+    if ((typeof item === "object") && (typeof item["dispose"] === "function"))
+        item["dispose"]();
 }
 
 /* ================================================================================================================= */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lepton-di",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A lightweight dependency injection framework for TypeScript",
   "main": "src/lib/index.js",
   "types": "src/lib/index.d.ts",


### PR DESCRIPTION
* Scopes now implement a cache so they do not have to walk up a parent chain every time.
* Items can not be added as unmanaged, so they will not be collected on scope destruction.
* Added maybeDispose() method which will call dispose() on an object if found.